### PR TITLE
Fix compatibility issue with Openfire 4.9.0

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -43,12 +43,13 @@
 Galene Plugin Changelog
 </h1>
 
-<p><b>0.8.1</b> -- <i>March 31, 2024</i></p>
+<p><b>0.8.1</b> -- <i>(to be determined)</i></p>
  <ul>
      <li>Update Galene code to 0.8.1</li>	 
     <li>Dropped support for win-32</li> 
     <li>Update Galene code</li> 	
 	<li>Marking that this version (and implicitly, later versions) are compatible with Openfire 4.8.0 and beyond</li>
+     <li>Fixes <a href="https://github.com/igniterealtime/openfire-galene-plugin/issues/6">issue #6</a>: Fix compatibility issue with Openfire 4.9.0</li>
  </ul> 
 
 <p><b>0.0.4</b> -- September 12, 2023</p>

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
     <description>${project.description}</description>
     <version>${project.version}</version>
     <licenseType>Apache 2.0</licenseType>
-    <date>2023-12-31</date>
+    <date>2024-09-11</date>
     <minServerVersion>4.8.0</minServerVersion>
 
    <adminconsole>

--- a/src/java/org/ifsoft/galene/openfire/Galene.java
+++ b/src/java/org/ifsoft/galene/openfire/Galene.java
@@ -63,7 +63,7 @@ public class Galene implements Plugin, PropertyEventListener, ProcessListener, M
     private XProcess galeneThread = null;
     private String galeneExePath = null;
     private String galeneHomePath = null;
-    private String galeneRoot = null;
+    private Path galeneRoot;
     private ExecutorService executor;
     private WebAppContext jspService;
     private GaleneIQHandler galeneIQHandler;
@@ -234,13 +234,11 @@ public class Galene implements Plugin, PropertyEventListener, ProcessListener, M
     {
         try
         {
-            galeneRoot = JiveGlobals.getHomeDirectory() + File.separator + "galene";
+            galeneRoot = JiveGlobals.getHomePath().resolve("galene");
 
-            File galeneRootPath = new File(galeneRoot);
-
-            if (!galeneRootPath.exists())
+            if (!Files.exists(galeneRoot))
             {
-                galeneRootPath.mkdirs();
+                Files.createDirectories(galeneRoot);
             }
 
             galeneHomePath = pluginDirectory.getAbsolutePath() + File.separator + "classes";


### PR DESCRIPTION
Replaced Openfire API usage that was deprecated in Openfire 4.8.0 and removed in 4.9.0.

fixes #6